### PR TITLE
adds the ability to set a custom video track name

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -85,6 +85,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 boolean maintainVideoTrackInBackground = args.getBoolean(7);
                 String cameraType = args.getString(8);
                 ReadableMap encodingParameters = args.getMap(9);
+                String videoTrackName = args.getString(10);
                 boolean enableH264Codec = encodingParameters.hasKey("enableH264Codec") ? encodingParameters.getBoolean("enableH264Codec") : false;
                 view.connectToRoomWrapper(
                     roomName,
@@ -96,7 +97,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                     dominantSpeakerEnabled,
                     maintainVideoTrackInBackground,
                     cameraType,
-                    enableH264Codec
+                    enableH264Codec,
+                    videoTrackName
                   );
                 break;
             case DISCONNECT:

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,9 +16,9 @@ declare module "react-native-twilio-video-webrtc" {
     scaleType?: scaleType;
     /**
      * Whether to apply Z ordering to this view.  Setting this to true will cause
-     * this view to appear above other Twilio Video views. 
+     * this view to appear above other Twilio Video views.
      */
-     applyZOrder?: boolean | undefined;
+    applyZOrder?: boolean | undefined;
   }
 
   interface TwilioVideoLocalViewProps extends ViewProps {
@@ -27,7 +27,7 @@ declare module "react-native-twilio-video-webrtc" {
     scaleType?: scaleType;
     /**
      * Whether to apply Z ordering to this view.  Setting this to true will cause
-     * this view to appear above other Twilio Video views. 
+     * this view to appear above other Twilio Video views.
      */
     applyZOrder?: boolean | undefined;
   }
@@ -85,13 +85,13 @@ declare module "react-native-twilio-video-webrtc" {
   export type RoomErrorEventCb = (t: RoomErrorEventArgs) => void;
 
   export type ParticipantEventCb = (p: ParticipantEventArgs) => void;
-  
+
   export type NetworkLevelChangeEventCb = (p: NetworkLevelChangeEventArgs) => void;
 
   export type DominantSpeakerChangedEventArgs = RoomEventCommonArgs & {
     participant: Participant;
   }
-  
+
   export type DominantSpeakerChangedCb = (d: DominantSpeakerChangedEventArgs) => void;
 
   export type LocalParticipantSupportedCodecsCbEventArgs = {
@@ -126,7 +126,7 @@ declare module "react-native-twilio-video-webrtc" {
     onStatsReceived?: (data: any) => void;
     onDataTrackMessageReceived?: DataTrackEventCb;
     // iOS only
-    autoInitializeCamera?: boolean;    
+    autoInitializeCamera?: boolean;
     ref?: React.Ref<any>;
   };
 
@@ -144,6 +144,7 @@ declare module "react-native-twilio-video-webrtc" {
       videoBitrate?: number;
     };
     enableNetworkQualityReporting?: boolean;
+    videoTrackName?: string;
   };
 
   type androidConnectParams = {
@@ -159,10 +160,11 @@ declare module "react-native-twilio-video-webrtc" {
     };
     enableNetworkQualityReporting?: boolean;
     maintainVideoTrackInBackground?: boolean;
+    videoTrackName?: string;
   };
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {
-    setLocalVideoEnabled: (enabled: boolean) => Promise<boolean>;
+    setLocalVideoEnabled: (enabled: boolean, videoTrackName?: string) => Promise<boolean>;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setRemoteAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setBluetoothHeadsetConnected: (enabled: boolean) => Promise<boolean>;

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -70,6 +70,7 @@ TVIVideoFormat *RCTTWVideoModuleCameraSourceSelectVideoFormatBySize(AVCaptureDev
 @property (strong, nonatomic) TVIAppScreenSource *screen;
 @property (strong, nonatomic) TVILocalParticipant* localParticipant;
 @property (strong, nonatomic) TVIRoom *room;
+@property (strong, nonatomic) NSString *customVideoTrackName;
 @property (nonatomic) BOOL listening;
 
 @end
@@ -173,7 +174,11 @@ RCT_EXPORT_METHOD(startLocalVideo) {
   if (self.camera == nil) {
       return;
   }
-  self.localVideoTrack = [TVILocalVideoTrack trackWithSource:self.camera enabled:NO name:@"camera"];
+  if (self.customVideoTrackName != nil) {
+    self.localVideoTrack = [TVILocalVideoTrack trackWithSource:self.camera enabled:NO name:self.customVideoTrackName];
+  } else {
+    self.localVideoTrack = [TVILocalVideoTrack trackWithSource:self.camera enabled:NO name:@"camera"];
+  }
 }
 
 - (void)startCameraCapture:(NSString *)cameraType {
@@ -302,7 +307,7 @@ RCT_EXPORT_METHOD(toggleScreenSharing: (BOOL) value) {
          TVILocalParticipant *localParticipant = self.room.localParticipant;
          [localParticipant publishVideoTrack:self.localVideoTrack];
        }
-       [self.screen startCapture];    
+       [self.screen startCapture];
   } else {
         [self unpublishLocalVideo];
         [self.screen stopCapture];
@@ -421,11 +426,13 @@ RCT_EXPORT_METHOD(getStats) {
   }
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType) {
+RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType videoTrackName:(NSString *)videoTrackName) {
   [self _setLocalVideoEnabled:enableVideo cameraType:cameraType];
   if (self.localAudioTrack) {
     [self.localAudioTrack setEnabled:enableAudio];
   }
+
+  self.customVideoTrackName = videoTrackName;
 
   TVIConnectOptions *connectOptions = [TVIConnectOptions optionsWithToken:accessToken block:^(TVIConnectOptionsBuilder * _Nonnull builder) {
     if (self.localVideoTrack) {
@@ -441,7 +448,7 @@ RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName 
     if (self.localDataTrack) {
       builder.dataTracks = @[self.localDataTrack];
     }
-      
+
     builder.dominantSpeakerEnabled = dominantSpeakerEnabled ? YES : NO;
 
     builder.roomName = roomName;

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -180,6 +180,7 @@ class CustomTwilioVideoView extends Component {
     dominantSpeakerEnabled = false,
     maintainVideoTrackInBackground = false,
     encodingParameters = {},
+    videoTrackName = "camera",
   }) {
     this.runCommand(nativeEvents.connectToRoom, [
       roomName,
@@ -192,6 +193,7 @@ class CustomTwilioVideoView extends Component {
       maintainVideoTrackInBackground,
       cameraType,
       encodingParameters,
+      videoTrackName,
     ]);
   }
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -249,6 +249,7 @@ export default class TwilioVideo extends Component {
     encodingParameters = null,
     enableNetworkQualityReporting = false,
     dominantSpeakerEnabled = false,
+    videoTrackName = "camera",
   }) {
     TWVideoModule.connect(
       accessToken,
@@ -258,7 +259,8 @@ export default class TwilioVideo extends Component {
       encodingParameters,
       enableNetworkQualityReporting,
       dominantSpeakerEnabled,
-      cameraType
+      cameraType,
+      videoTrackName
     );
   }
 


### PR DESCRIPTION
Adding the ability to define a custom track on `connect` or room connection. The other location we might define a way to recreate the track with a custom track name is when we flip the camera. We'll have all the necessary context and that seems to be the scenario that makes the most sense where you might want to rename the video track.

Currently testing within the RN SDK via Streem Next.