### PR TITLE
Task/st 4097 data track (native)

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -30,6 +30,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_VIDEO_CHANGED
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_REMOVED_DATA_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_DATA_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DATATRACK_MESSAGE_RECEIVED;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DATATRACK_BINARY_MESSAGE_RECEIVED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_VIDEO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_REMOVED_VIDEO_TRACK;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_PARTICIPANT_ADDED_AUDIO_TRACK;
@@ -61,6 +62,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int PUBLISH_VIDEO = 13;
     private static final int PUBLISH_AUDIO = 14;
     private static final int PREPARE_TO_REBUILD_LOCAL_VIDEO_TRACK = 15;
+
 
     @Override
     public String getName() {
@@ -173,12 +175,16 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
 
         map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_DISCONNECTED, MapBuilder.of("registrationName", ON_PARTICIPANT_DISCONNECTED),
-                ON_DATATRACK_MESSAGE_RECEIVED, MapBuilder.of("registrationName", ON_DATATRACK_MESSAGE_RECEIVED),
                 ON_PARTICIPANT_ADDED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ADDED_DATA_TRACK),
                 ON_PARTICIPANT_ADDED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ADDED_VIDEO_TRACK),
                 ON_PARTICIPANT_REMOVED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_VIDEO_TRACK),
                 ON_PARTICIPANT_ADDED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ADDED_AUDIO_TRACK),
                 ON_PARTICIPANT_REMOVED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_AUDIO_TRACK)
+        ));
+
+        map.putAll(MapBuilder.of(
+                ON_DATATRACK_MESSAGE_RECEIVED, MapBuilder.of("registrationName", ON_DATATRACK_MESSAGE_RECEIVED),
+                ON_DATATRACK_BINARY_MESSAGE_RECEIVED, MapBuilder.of("registrationName", ON_DATATRACK_BINARY_MESSAGE_RECEIVED)
         ));
 
         map.putAll(MapBuilder.of(

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,13 @@ declare module "react-native-twilio-video-webrtc" {
     trackSid: string;
   }
 
+  export interface DataTrackBinaryEventCbArgs {
+    message: Uint8Array;
+    trackSid: string;
+  }
+
   export type DataTrackEventCb = (t: DataTrackEventCbArgs) => void;
+  export type DataTrackBinaryEventCb = (t: DataTrackBinaryEventCbArgs) => void;
 
   interface RoomEventCommonArgs {
     roomName: string;
@@ -86,19 +92,25 @@ declare module "react-native-twilio-video-webrtc" {
 
   export type ParticipantEventCb = (p: ParticipantEventArgs) => void;
 
-  export type NetworkLevelChangeEventCb = (p: NetworkLevelChangeEventArgs) => void;
+  export type NetworkLevelChangeEventCb = (
+    p: NetworkLevelChangeEventArgs
+  ) => void;
 
   export type DominantSpeakerChangedEventArgs = RoomEventCommonArgs & {
     participant: Participant;
-  }
+  };
 
-  export type DominantSpeakerChangedCb = (d: DominantSpeakerChangedEventArgs) => void;
+  export type DominantSpeakerChangedCb = (
+    d: DominantSpeakerChangedEventArgs
+  ) => void;
 
   export type LocalParticipantSupportedCodecsCbEventArgs = {
     supportedCodecs: Array<string>;
-  }
+  };
 
-  export type LocalParticipantSupportedCodecsCb = (d: LocalParticipantSupportedCodecsCbEventArgs) => void;
+  export type LocalParticipantSupportedCodecsCb = (
+    d: LocalParticipantSupportedCodecsCbEventArgs
+  ) => void;
 
   export type TwilioVideoProps = ViewProps & {
     onCameraDidStart?: () => void;
@@ -122,9 +134,10 @@ declare module "react-native-twilio-video-webrtc" {
     onRoomParticipantDidDisconnect?: ParticipantEventCb;
     onNetworkQualityLevelsChanged?: NetworkLevelChangeEventCb;
     onLocalParticipantSupportedCodecs?: LocalParticipantSupportedCodecsCb;
-
     onStatsReceived?: (data: any) => void;
     onDataTrackMessageReceived?: DataTrackEventCb;
+    onDataTrackBinaryMessageReceived?: DataTrackBinaryEventCb;
+
     localVideoTrackName?: string;
     // iOS only
     autoInitializeCamera?: boolean;
@@ -163,7 +176,10 @@ declare module "react-native-twilio-video-webrtc" {
   };
 
   class TwilioVideo extends React.Component<TwilioVideoProps> {
-    setLocalVideoEnabled: (enabled: boolean, cameraType?: cameraType) => Promise<boolean>;
+    setLocalVideoEnabled: (
+      enabled: boolean,
+      cameraType?: cameraType
+    ) => Promise<boolean>;
     setLocalAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setRemoteAudioEnabled: (enabled: boolean) => Promise<boolean>;
     setBluetoothHeadsetConnected: (enabled: boolean) => Promise<boolean>;
@@ -190,13 +206,9 @@ declare module "react-native-twilio-video-webrtc" {
     prepareToRebuildLocalVideoTrack: (localVideoTrackName: string) => void;
   }
 
-  class TwilioVideoLocalView extends React.Component<
-    TwilioVideoLocalViewProps
-  > {}
+  class TwilioVideoLocalView extends React.Component<TwilioVideoLocalViewProps> {}
 
-  class TwilioVideoParticipantView extends React.Component<
-    TwilioVideoParticipantViewProps
-  > {}
+  class TwilioVideoParticipantView extends React.Component<TwilioVideoParticipantViewProps> {}
 
   export { TwilioVideoLocalView, TwilioVideoParticipantView, TwilioVideo };
 }

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -28,6 +28,7 @@ static NSString* participantDisabledVideoTrack     = @"participantDisabledVideoT
 static NSString* participantEnabledAudioTrack      = @"participantEnabledAudioTrack";
 static NSString* participantDisabledAudioTrack     = @"participantDisabledAudioTrack";
 static NSString* dataTrackMessageReceived     = @"dataTrackMessageReceived";
+static NSString* dataTrackBinaryMessageReceived     = @"dataTrackBinaryMessageReceived";
 
 static NSString* cameraDidStart               = @"cameraDidStart";
 static NSString* cameraWasInterrupted         = @"cameraWasInterrupted";
@@ -107,6 +108,7 @@ RCT_EXPORT_MODULE();
     participantEnabledAudioTrack,
     participantDisabledAudioTrack,
     dataTrackMessageReceived,
+    dataTrackBinaryMessageReceived,
     cameraDidStopRunning,
     cameraDidStart,
     cameraWasInterrupted,
@@ -711,8 +713,8 @@ RCT_EXPORT_METHOD(disconnect) {
 }
 
 - (void)remoteDataTrack:(nonnull TVIRemoteDataTrack *)remoteDataTrack didReceiveData:(nonnull NSData *)message {
-    // TODO: Handle didReceiveData
-    NSLog(@"DataTrack didReceiveData");
+    NSString *base64String = [message base64EncodedStringWithOptions:0];
+    [self sendEventCheckingListenerWithName:dataTrackBinaryMessageReceived body:@{ @"message": base64String, @"trackSid": remoteDataTrack.sid }];
 }
 
 # pragma mark - TVILocalParticipantDelegate

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     }
   },
   "dependencies": {
+    "base64-js": "^1.5.1",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -17,6 +17,7 @@ import {
 import React, { Component } from "react";
 
 import PropTypes from "prop-types";
+import { toByteArray } from "base64-js";
 
 const propTypes = {
   ...View.propTypes,
@@ -70,6 +71,13 @@ const propTypes = {
    * @param {{message}}
    */
   onDataTrackMessageReceived: PropTypes.func,
+
+  /**
+   * Called when an dataTrack receives a binary message
+   *
+   * @param {{message}}
+   */
+  onDataTrackBinaryMessageReceived: PropTypes.func,
 
   /**
    * Called when a new video track has been added
@@ -293,6 +301,7 @@ class CustomTwilioVideoView extends Component {
       "onParticipantAddedDataTrack",
       "onParticipantRemovedDataTrack",
       "onDataTrackMessageReceived",
+      "onDataTrackBinaryMessageReceived",
       "onParticipantAddedVideoTrack",
       "onParticipantRemovedVideoTrack",
       "onParticipantAddedAudioTrack",
@@ -308,10 +317,19 @@ class CustomTwilioVideoView extends Component {
       "onDominantSpeakerDidChange",
       "onLocalParticipantSupportedCodecs",
     ].reduce((wrappedEvents, eventName) => {
+      let handler = (data) => this.props[eventName](data.nativeEvent);
+
       if (this.props[eventName]) {
+        if (eventName === "onDataTrackBinaryMessageReceived") {
+          handler = (data) =>
+            this.props[eventName]({
+              ...data.nativeEvent,
+              message: toByteArray(data.nativeEvent.message),
+            });
+        }
         return {
           ...wrappedEvents,
-          [eventName]: (data) => this.props[eventName](data.nativeEvent),
+          [eventName]: handler,
         };
       }
       return wrappedEvents;

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -9,6 +9,7 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 import { NativeModules, NativeEventEmitter, View } from "react-native";
+import { toByteArray } from "base64-js";
 
 const { TWVideoModule } = NativeModules;
 
@@ -105,11 +106,17 @@ export default class TwilioVideo extends Component {
      */
     onParticipantDisabledAudioTrack: PropTypes.func,
     /**
-     * Called when an dataTrack receives a message
+     * Called when a dataTrack receives a message
      *
      * @param {{message}}
      */
     onDataTrackMessageReceived: PropTypes.func,
+    /**
+     * Called when a dataTrack receives a binary message
+     *
+     * @param {{message}}
+     */
+    onDataTrackBinaryMessageReceived: PropTypes.func,
     /**
      * Called when the camera has started
      *
@@ -438,13 +445,25 @@ export default class TwilioVideo extends Component {
             if (this.props.onParticipantDisabledAudioTrack) {
               this.props.onParticipantDisabledAudioTrack(data);
             }
-          }
+        }
       ),
       this._eventEmitter.addListener("dataTrackMessageReceived", (data) => {
         if (this.props.onDataTrackMessageReceived) {
           this.props.onDataTrackMessageReceived(data);
         }
       }),
+      this._eventEmitter.addListener(
+        "dataTrackBinaryMessageReceived",
+        (data) => {
+          if (this.props.onDataTrackBinaryMessageReceived) {
+            const byteArray = toByteArray(data.message);
+            this.props.onDataTrackBinaryMessageReceived({
+              ...data,
+              message: byteArray,
+            });
+          }
+        }
+      ),
       this._eventEmitter.addListener("cameraDidStart", (data) => {
         if (this.props.onCameraDidStart) {
           this.props.onCameraDidStart(data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,6 +2662,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base-64@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
+  integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
+
 base64-js@^1.2.3, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"


### PR DESCRIPTION
Enables us to receive and decode the data sent over the data track when the expert uses the laser, marker, etc.
This PR should be tested in conjunction with [this SDK code](https://github.com/streem/streem-app/pull/13804).

To test:
1. Run `yarn install` to install the new `base-64-js` dependency.
2. Start a call on streem-next (using [this branch](https://github.com/streem/streem-app/pull/13804) so that the proper listeners get set up) 
3. On the expert side, use the laser or drawing tool.
4. Search for `onDataTrackBinaryMessageReceived` in the JS logs. You should see the data track messages being printed out in readable text. If the logs are printing out, success!!