### PR TITLE
Issue/st 4060: capture frame w/ filename

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -824,9 +824,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
     }
 
-    public void captureFrame() {
+    public void captureFrame(String filename) {
         if (videoProcessor != null) {
-            videoProcessor.captureFrame();
+            videoProcessor.captureFrame(filename);
         } else {
             Log.e(TAG, "Failed to call captureFrame. Video processor is not initialized");
         }
@@ -1364,7 +1364,7 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     public static void registerThumbnailVideoView(PatchedVideoView v) {
         thumbnailVideoView = v;
         videoProcessor.setVideoView(v);
-        videoProcessor.setContext(v.getContext().getApplicationContext());
+        videoProcessor.setContext(v.getContext());
         if (localVideoTrack != null) {
             localVideoTrack.addSink(v);
             localVideoTrack.getVideoSource().setVideoProcessor(videoProcessor);

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -44,6 +44,8 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALI
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DOMINANT_SPEAKER_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS;
 
+import android.util.Log;
+
 public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilioVideoView> {
     public static final String REACT_CLASS = "RNCustomTwilioVideoView";
 
@@ -159,7 +161,8 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 view.prepareToRebuildLocalVideoTrack(args.getString(0));
                 break;
             case CAPTURE_FRAME:
-                view.captureFrame();
+                Log.d(TwilioPackage.TAG, String.format("capture frame: %s", args.getString(0) == null ? "null" : args.getString(0)));
+                view.captureFrame(args.getString(0));
                 break;
         }
     }

--- a/android/src/main/java/com/twiliorn/library/CustomVideoProcessor.java
+++ b/android/src/main/java/com/twiliorn/library/CustomVideoProcessor.java
@@ -21,15 +21,18 @@ public class CustomVideoProcessor implements VideoProcessor {
     private final AtomicBoolean canCapture = new AtomicBoolean(false);
     private final AtomicBoolean captureThisFrame = new AtomicBoolean(false);
     private PatchedVideoView videoView;
+    // TODO: FIX THIS. ITS A POTENTIAL MEMORY LEAK.
     private Context context;
     // choosing to use single thread since limited i/o resources may be a bottleneck anyways
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private String filename = "";
 
     public CustomVideoProcessor() {}
 
-    public void captureFrame() {
+    public void captureFrame(String filename) {
         if (canCapture.get()) {
-            Log.d(TwilioPackage.TAG, "Setting captureThisFrame flag to true.");
+            this.filename = filename;
+            Log.d(TwilioPackage.TAG, "Setting captureThisFrame flag to true for file " + filename);
             captureThisFrame.set(true);
         }
         else {
@@ -57,7 +60,7 @@ public class CustomVideoProcessor implements VideoProcessor {
             Log.d(TwilioPackage.TAG, "Capturing frame on background thread.");
             // save frame on background thread
             executorService.execute(() -> {
-                Utils.saveVideoFrame(frame, context);
+                Utils.saveVideoFrame(frame, context, this.filename);
             });
         }
 
@@ -80,7 +83,6 @@ public class CustomVideoProcessor implements VideoProcessor {
 
     @Override
     public void onCapturerStopped() {
-
         canCapture.set(false);
         captureThisFrame.set(false);
     }

--- a/android/src/main/java/com/twiliorn/library/Utils.java
+++ b/android/src/main/java/com/twiliorn/library/Utils.java
@@ -58,11 +58,11 @@ public final class Utils {
     }
 
     // i420 -> nv21 -> yuv -> jpeg
-    public static void saveVideoFrame(VideoFrame frame, Context context) {
+    public static void saveVideoFrame(VideoFrame frame, Context context, String filename) {
         Log.d(TwilioPackage.TAG, "saving video frame");
         String fileId = UUID.randomUUID().toString();
-        String filename = "rntframe-" + fileId + ".jpeg";
-        Log.d(TwilioPackage.TAG, "saving frame for file " + filename);
+        String filePath = filename + ".jpeg";
+        Log.d(TwilioPackage.TAG, "saving frame for file " + filePath);
 
         VideoFrame.I420Buffer i420Buffer = frame.getBuffer().toI420();
         final int width = i420Buffer.getWidth();
@@ -77,13 +77,13 @@ public final class Utils {
         byte[] rawImageBytes = out.toByteArray();
         byte[] imageBytes = rotateJPEGByteArray(rawImageBytes, frame.getRotation());
 
-        try (FileOutputStream fos = context.openFileOutput(filename, Context.MODE_PRIVATE)) {
+        try (FileOutputStream fos = context.openFileOutput(filePath, Context.MODE_PRIVATE)) {
             // write image to disk
             fos.write(imageBytes);
-            Log.d(TwilioPackage.TAG, "saved frame to " + filename);
+            Log.d(TwilioPackage.TAG, "saved frame to " + filePath);
             // send event to JS w/ filename
             WritableMap params = Arguments.createMap();
-            params.putString("filename", filename);
+            params.putString("filename", filePath);
             sendEvent(context, "onFrameCaptured", params);
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);

--- a/index.d.ts
+++ b/index.d.ts
@@ -215,7 +215,7 @@ declare module 'react-native-twilio-video-webrtc' {
      *
      * `import { DeviceEventEmitter } from 'react-native';`
      */
-    captureFrame: () => void;
+    captureFrame: (filename: string) => void;
   }
 
   class TwilioVideoLocalView extends React.Component<TwilioVideoLocalViewProps> {}

--- a/ios/RCTTWFrameCaptureRenderer.h
+++ b/ios/RCTTWFrameCaptureRenderer.h
@@ -10,7 +10,8 @@
 @interface RCTTWFrameCaptureRenderer : NSObject<TVIVideoRenderer>
 
 @property (nonatomic) BOOL captureThisFrame;
+@property (nonatomic) NSString *filename;
 
-- (void) captureFrame;
+- (void) captureFrame:(NSString *)filename;
 
 @end

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -181,8 +181,8 @@ RCT_EXPORT_MODULE();
   }
 }
 
-RCT_EXPORT_METHOD(captureFrame) {
-    [self.captureRenderer captureFrame];
+RCT_EXPORT_METHOD(captureFrame:(NSString *)filename) {
+    [self.captureRenderer captureFrame:filename];
 }
 
 RCT_EXPORT_METHOD(changeListenerStatus:(BOOL)value) {

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -277,8 +277,8 @@ class CustomTwilioVideoView extends Component {
     this.runCommand(nativeEvents.toggleSoundSetup, [speaker]);
   }
 
-  captureFrame() {
-    this.runCommand(nativeEvents.captureFrame, []);
+  captureFrame(filename) {
+    this.runCommand(nativeEvents.captureFrame, [filename]);
   }
 
   runCommand(event, args) {

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -337,8 +337,8 @@ export default class TwilioVideo extends Component {
     TWVideoModule.sendString(message);
   }
 
-  captureFrame() {
-    TWVideoModule.captureFrame();
+  captureFrame(filename) {
+    TWVideoModule.captureFrame(filename);
   }
 
   _setLocalVideoTrackName(name) {


### PR DESCRIPTION
This adds ability for frontend to provide custom filename for captured frame.

This way the frontend can match captured frames back to their app logic.

For example, you can imagine we might save the filename as the streemshot wall item request id or whatever so we know which captured frames are associated with what calls, etc

Associated frontend PR: https://github.com/streem/streem-app/pull/13910