### PR TITLE
Task/st 4107 add flashlight control to twiliosdk

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -43,6 +43,7 @@ import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_STATS_RECEIVE
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_NETWORK_QUALITY_LEVELS_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_DOMINANT_SPEAKER_CHANGED;
 import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS;
+import static com.twiliorn.library.CustomTwilioVideoView.Events.ON_FLASHLIGHT_STATUS_CHANGED;
 
 import android.util.Log;
 
@@ -65,6 +66,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
     private static final int PUBLISH_AUDIO = 14;
     private static final int PREPARE_TO_REBUILD_LOCAL_VIDEO_TRACK = 15;
     private static final int CAPTURE_FRAME = 16;
+    private static final int SET_FLASHLIGHT_STATUS = 17;
 
 
     @Override
@@ -164,6 +166,9 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 Log.d(TwilioPackage.TAG, String.format("capture frame: %s", args.getString(0) == null ? "null" : args.getString(0)));
                 view.captureFrame(args.getString(0));
                 break;
+            case SET_FLASHLIGHT_STATUS:
+                view.setFlashlightStatus(args.getBoolean(0));
+                break;
         }
     }
 
@@ -192,6 +197,10 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
         map.putAll(MapBuilder.of(
                 ON_DATATRACK_MESSAGE_RECEIVED, MapBuilder.of("registrationName", ON_DATATRACK_MESSAGE_RECEIVED),
                 ON_DATATRACK_BINARY_MESSAGE_RECEIVED, MapBuilder.of("registrationName", ON_DATATRACK_BINARY_MESSAGE_RECEIVED)
+        ));
+
+        map.putAll(MapBuilder.of(
+                ON_FLASHLIGHT_STATUS_CHANGED, MapBuilder.of("registrationName", ON_FLASHLIGHT_STATUS_CHANGED)
         ));
 
         map.putAll(MapBuilder.of(
@@ -230,6 +239,7 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
                 .put("publishAudio", PUBLISH_AUDIO)
                 .put("prepareToRebuildLocalVideoTrack", PREPARE_TO_REBUILD_LOCAL_VIDEO_TRACK)
                 .put("captureFrame", CAPTURE_FRAME)
+                .put("setFlashlightStatus", SET_FLASHLIGHT_STATUS)
                 .build();
     }
 }

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -209,6 +209,10 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
         ));
 
         map.putAll(MapBuilder.of(
+                ON_FLASHLIGHT_STATUS_CHANGED, MapBuilder.of("registrationName", ON_FLASHLIGHT_STATUS_CHANGED)
+        ));
+
+        map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_ENABLED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ENABLED_VIDEO_TRACK),
                 ON_PARTICIPANT_DISABLED_VIDEO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_DISABLED_VIDEO_TRACK),
                 ON_PARTICIPANT_ENABLED_AUDIO_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_ENABLED_AUDIO_TRACK),

--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoViewManager.java
@@ -200,10 +200,6 @@ public class CustomTwilioVideoViewManager extends SimpleViewManager<CustomTwilio
         ));
 
         map.putAll(MapBuilder.of(
-                ON_FLASHLIGHT_STATUS_CHANGED, MapBuilder.of("registrationName", ON_FLASHLIGHT_STATUS_CHANGED)
-        ));
-
-        map.putAll(MapBuilder.of(
                 ON_PARTICIPANT_REMOVED_DATA_TRACK, MapBuilder.of("registrationName", ON_PARTICIPANT_REMOVED_DATA_TRACK),
                 ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS, MapBuilder.of("registrationName", ON_LOCAL_PARTICIPANT_SUPPORTED_CODECS)
         ));

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ onParticipantDisabledAudioTrack | func | no |  | Called when an audio track has 
 onStatsReceived | func | no |  | Callback that is called when stats are received (after calling getStats)
 onNetworkQualityLevelsChanged | func | no |  | Callback that is called when network quality levels are changed (only if enableNetworkQualityReporting in connect is set to true)
 onDominantSpeakerDidChange | func | no |  | Called when dominant speaker changes @param {{ participant, room }} dominant participant and room
+onFlashlightStatusChanged | func | no |  | Called when flashlight status changes @param {{ status }} flashlight status
 -----
 
 **src/TwilioVideo.ios.js**
@@ -71,6 +72,7 @@ onStatsReceived | func | no |  | Called when stats are received (after calling g
 onNetworkQualityLevelsChanged | func | no |  | Called when the network quality levels of a participant have changed (only if enableNetworkQualityReporting is set to True when connecting)
 onDominantSpeakerDidChange | func | no |  | Called when dominant speaker changes @param {{ participant, room }} dominant participant
 onLocalParticipantSupportedCodecs | func | no |  | Always called on android with @param {{ supportedCodecs }} after connecting to the room
+onFlashlightStatusChanged | func | no |  | Called when flashlight status changes @param {{ status }} flashlight status
 
 -----
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,8 @@ declare module 'react-native-twilio-video-webrtc' {
     p: NetworkLevelChangeEventArgs,
   ) => void;
 
+  export type FlashlightStatusChanged = (status: boolean, error?: string) => void;
+
   export type DominantSpeakerChangedEventArgs = RoomEventCommonArgs & {
     participant: Participant;
   };
@@ -128,6 +130,7 @@ declare module 'react-native-twilio-video-webrtc' {
     onParticipantAddedDataTrack?: TrackEventCb;
     onParticipantRemovedDataTrack?: TrackEventCb;
     onRoomDidConnect?: RoomEventCb;
+    onFlashlightStatusChanged?: (enabled: boolean) => FlashlightStatusChanged;
     onRoomDidDisconnect?: RoomErrorEventCb;
     onRoomDidFailToConnect?: RoomErrorEventCb;
     onRoomParticipantDidConnect?: ParticipantEventCb;
@@ -187,6 +190,7 @@ declare module 'react-native-twilio-video-webrtc' {
     disconnect: () => void;
     flipCamera: () => void;
     toggleSoundSetup: (speaker: boolean) => void;
+    setFlashlightStatus: (enabled: boolean) => void;
     getStats: () => void;
     publishLocalAudio: () => void;
     unpublishLocalAudio: () => void;

--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -38,6 +38,7 @@ static NSString* cameraDidStopRunning         = @"cameraDidStopRunning";
 static NSString* statsReceived                = @"statsReceived";
 static NSString* networkQualityLevelsChanged  = @"networkQualityLevelsChanged";
 static NSString* onFrameCaptured = @"onFrameCaptured";
+static NSString* onFlashlightStatusChanged = @"onFlashlightStatusChanged";
 
 static const CMVideoDimensions kRCTTWVideoAppCameraSourceDimensions = (CMVideoDimensions){900, 720};
 
@@ -120,7 +121,8 @@ RCT_EXPORT_MODULE();
     statsReceived,
     networkQualityLevelsChanged,
     dominantSpeakerDidChange,
-    onFrameCaptured
+    onFrameCaptured,
+    onFlashlightStatusChanged
   ];
 }
 
@@ -421,6 +423,32 @@ RCT_EXPORT_METHOD(toggleScreenSharing: (BOOL) value) {
        }
 }
 
+RCT_EXPORT_METHOD(setFlashlightStatus:(BOOL)isEnabled) {
+  NSMutableDictionary *body = [[NSMutableDictionary alloc] init];
+  if (self.camera) {
+        AVCaptureDevice *device = self.camera.device;
+        if ([device hasTorch]){
+            [device lockForConfiguration:nil];
+            if (device.torchActive == isEnabled) {
+              // noop, flash is already in selected state
+            } else {
+              if (isEnabled) {
+                  [device setTorchMode:AVCaptureTorchModeOn];
+              } else {
+                  [device setTorchMode:AVCaptureTorchModeOff];
+              }
+              BOOL isFlashOn = device.torchActive;
+              [device unlockForConfiguration];
+              [body addEntriesFromDictionary:@{ @"isFlashOn" : [NSNumber numberWithBool:!isFlashOn] }];
+            }
+        } else {
+           [body addEntriesFromDictionary:@{ @"error" : @"Flash is not supported in current camera mode" }];
+        }
+  } else {
+    [body addEntriesFromDictionary:@{ @"error" : @"There's no camera available" }];
+  }
+  [self sendEventCheckingListenerWithName:onFlashlightStatusChanged body:body];
+}
 
 RCT_EXPORT_METHOD(toggleSoundSetup:(BOOL)speaker) {
   NSError *error = nil;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.0",
     "@types/react-native": "~0.70.6",
     "babel-eslint": "^7.2.3",
     "del": "^3.0.0",

--- a/src/TwilioVideo.android.js
+++ b/src/TwilioVideo.android.js
@@ -161,6 +161,11 @@ const propTypes = {
    * The name of the local video track.  Defaults to "camera"
    */
   localVideoTrackName: PropTypes.string,
+  /**
+   * Called when torch is done attempting to change status
+   * @param {{ status, error }} 
+   */
+  onFlashlightStatusChanged: PropTypes.func,
 };
 
 const nativeEvents = {
@@ -180,6 +185,7 @@ const nativeEvents = {
   publishAudio: 14,
   prepareToRebuildLocalVideoTrack: 15,
   captureFrame: 16,
+  setFlashlightStatus: 17,
 };
 
 class CustomTwilioVideoView extends Component {
@@ -265,6 +271,10 @@ class CustomTwilioVideoView extends Component {
     return Promise.resolve(enabled);
   }
 
+  setFlashlightStatus(enabled) {
+    this.runCommand(nativeEvents.setFlashlightStatus, [enabled]);
+  }
+
   getStats() {
     this.runCommand(nativeEvents.getStats, []);
   }
@@ -321,6 +331,7 @@ class CustomTwilioVideoView extends Component {
       "onNetworkQualityLevelsChanged",
       "onDominantSpeakerDidChange",
       "onLocalParticipantSupportedCodecs",
+      "onFlashlightStatusChanged",
     ].reduce((wrappedEvents, eventName) => {
       let handler = (data) => this.props[eventName](data.nativeEvent);
 

--- a/src/TwilioVideo.ios.js
+++ b/src/TwilioVideo.ios.js
@@ -154,6 +154,11 @@ export default class TwilioVideo extends Component {
      */
     onDominantSpeakerDidChange: PropTypes.func,
     /**
+     * Called when the flashlight status changes
+     * @param {{ status, error }} 
+     */
+    onFlashlightStatusChanged: PropTypes.func,
+    /**
      * Whether or not video should be automatically initialized upon mounting
      * of this component. Defaults to true. If set to false, any use of the
      * camera will require calling `_startLocalVideo`.
@@ -208,6 +213,10 @@ export default class TwilioVideo extends Component {
 
   setBluetoothHeadsetConnected(enabled) {
     return Promise.resolve(enabled);
+  }
+
+  setFlashlightStatus(enabled) {
+    TWVideoModule.setFlashlightStatus(enabled);
   }
 
   /**
@@ -501,6 +510,11 @@ export default class TwilioVideo extends Component {
       this._eventEmitter.addListener("onDominantSpeakerDidChange", (data) => {
         if (this.props.onDominantSpeakerDidChange) {
           this.props.onDominantSpeakerDidChange(data);
+        }
+      }),
+      this._eventEmitter.addListener("onFlashlightStatusChanged", (data) => {
+        if (this.props.onFlashlightStatusChanged) {
+          this.props.onFlashlightStatusChanged(data);
         }
       }),
     ];


### PR DESCRIPTION
Added ability to change flashlight status. I followed the pattern that we have in the code already where there is both a method to perform the change (like flipCamera) but also a callback method (i.e. onCameraSwitched). I don't know that we need the second one but I wanted to be consistent with the other methods provided. Happy to change it though. Code was adapted from[ this example](https://github.com/blackuy/react-native-twilio-video-webrtc/pull/457/files) which is stuck in PR to the main fork since March 2021. 