### PR TITLE
use captured remote aspect ratio

### DIFF
--- a/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
+++ b/android/src/main/java/com/twiliorn/library/RNVideoViewGroup.java
@@ -7,6 +7,7 @@
 package com.twiliorn.library;
 
 import android.graphics.Point;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.StringDef;
@@ -31,6 +32,7 @@ public class RNVideoViewGroup extends ViewGroup {
     private final Object layoutSync = new Object();
     private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FILL;
     private final RCTEventEmitter eventEmitter;
+    public boolean isRemote;
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({ON_FRAME_DIMENSIONS_CHANGED})
@@ -107,9 +109,15 @@ public class RNVideoViewGroup extends ViewGroup {
                 videoWidth = 640;
             }
 
+            float aspectRatio = (float) videoWidth / (float) videoHeight;
+            if (isRemote) {
+                // NOTE: this is the aspect ratio the remote video is captured at
+                aspectRatio = 1.7777777778f;
+            }
+
             Point displaySize = RendererCommon.getDisplaySize(
                     this.scalingType,
-                    videoWidth / (float) videoHeight,
+                    aspectRatio,
                     width,
                     height
             );

--- a/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioRemotePreview.java
@@ -19,6 +19,7 @@ public class TwilioRemotePreview extends RNVideoViewGroup {
 
     public TwilioRemotePreview(ThemedReactContext context, String trackSid) {
         super(context);
+        this.isRemote = true;
         Log.i("CustomTwilioVideoView", "Remote Prview Construct");
         Log.i("CustomTwilioVideoView", trackSid);
 

--- a/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
+++ b/android/src/main/java/com/twiliorn/library/TwilioVideoPreview.java
@@ -15,6 +15,7 @@ public class TwilioVideoPreview extends RNVideoViewGroup {
 
     public TwilioVideoPreview(ThemedReactContext themedReactContext) {
         super(themedReactContext);
+        this.isRemote = false;
         CustomTwilioVideoView.registerThumbnailVideoView(this.getSurfaceViewRenderer());
     }
 


### PR DESCRIPTION
When rendering the remote video, we use the aspect ratio that it was captured at which is the pretty standard 16:9