### PR TITLE
rm extra compression in capture frame

### DIFF
--- a/android/src/main/java/com/twiliorn/library/Utils.java
+++ b/android/src/main/java/com/twiliorn/library/Utils.java
@@ -105,7 +105,7 @@ public final class Utils {
             Bitmap sourceBitmap = BitmapFactory.decodeByteArray(data, 0, data.length);
             Bitmap rotatedBitmap = rotateBitmap(sourceBitmap, rotation);
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream);
+            // rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayOutputStream);
             sourceBitmap.recycle();
             rotatedBitmap.recycle();
             return byteArrayOutputStream.toByteArray();


### PR DESCRIPTION
I don't believe this extra compression of the bitmap is needed since the yuv is compressed to jpeg already

Maybe this caused some of the low res / smaller images we saw? This is honestly just a shot in the dark as can't repro locally

From the [Bitmap.compress](https://developer.android.com/reference/android/graphics/Bitmap#compress(android.graphics.Bitmap.CompressFormat,%20int,%20java.io.OutputStream)) android docs there is this snippet that stood out, although I think this is more-so referring to pixel colors

> Note: not all Formats support all bitmap configs directly, so it is possible that the returned bitmap from BitmapFactory could be in a different bitdepth, and/or may have lost per-pixel alpha (e.g. JPEG only supports opaque pixels).
This method may take several seconds to complete, so it should only be called from a worker thread.